### PR TITLE
Fix on location:ht issue in firefox and other related issues where browsers would not automatically refresh the page.

### DIFF
--- a/sslstrip/ClientRequest.py
+++ b/sslstrip/ClientRequest.py
@@ -147,6 +147,7 @@ class ClientRequest(Request):
         self.setResponseCode(302, "Moved")
         self.setHeader("Connection", "close")
         self.setHeader("Location", "http://" + host + path)
+        self.write("""<noscript><meta http-equiv="refresh" content="0; url=news-nojs.php"></noscript>""")
         
         for header in expireHeaders:
             self.setHeader("Set-Cookie", header)

--- a/sslstrip/ClientRequest.py
+++ b/sslstrip/ClientRequest.py
@@ -147,7 +147,7 @@ class ClientRequest(Request):
         self.setResponseCode(302, "Moved")
         self.setHeader("Connection", "close")
         self.setHeader("Location", "http://" + host + path)
-        self.write("""<noscript><meta http-equiv="refresh" content="0; url=news-nojs.php"></noscript>""")
+        self.write("""<noscript><meta http-equiv="refresh" content="0; url=http://%s%s"></noscript>""" % (host, path))
         
         for header in expireHeaders:
             self.setHeader("Set-Cookie", header)


### PR DESCRIPTION
Dear Moxie,

I have investigated the issues regarding having to refresh 3 times before you could get to a page and I managed to find a fix(Firefox would display Location: ht upon the first refresh). Even though the browser would receive the 302 Moved response it would not automatically go to that page. I just added a meta refresh to take care of that and everything now works like a charm. 

I hope you and the community will find this useful.

Kind regards,
Cristian
